### PR TITLE
fix(1754): [2] Pass config to `getUploadCoverageCmd` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class CoverageBookend extends BookendInterface {
         }
 
         // Set 'enabled' config into specified plugin instance.
-        config[pluginName]['enabled'] = config.enabled;
+        config[pluginName].enabled = config.enabled;
 
         this.coveragePlugin = new CoveragePlugin(config[pluginName]);
     }

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ class CoverageBookend extends BookendInterface {
             return;
         }
 
-        // Set 'enabled' config into specified plugin instance.
-        config[pluginName].enabled = config.enabled;
+        // Set cluster default enable config into specified plugin instance.
+        config[pluginName].default = config.default;
 
         this.coveragePlugin = new CoveragePlugin(config[pluginName]);
     }

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ class CoverageBookend extends BookendInterface {
             return;
         }
 
+        // Set 'enabled' config into specified plugin instance.
+        config[pluginName]['enabled'] = config.enabled;
+
         this.coveragePlugin = new CoveragePlugin(config[pluginName]);
     }
 
@@ -48,8 +51,8 @@ class CoverageBookend extends BookendInterface {
      * @method getTeardownCommand
      * @return {Promise}           Resolves to a string that represents the commmand to execute
      */
-    getTeardownCommand() {
-        return this.coveragePlugin.getUploadCoverageCmd();
+    getTeardownCommand(config) {
+        return this.coveragePlugin.getUploadCoverageCmd(config);
     }
 }
 


### PR DESCRIPTION
## Context
When we use coverage-bookend, coverage scanning is executed all jobs, including jobs which is not necessary to scan.
It must be leads to longer build time, or surging database size.

## Objective
- Pass build config to `getUploadCoverageCmd` function in order to verify coverage plugin enables or not
- Set cluster level configuration(`coverage.default`: `true` / `false`) into each coverage plugin instance.

## References
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1754
Other PRs
[1]: https://github.com/screwdriver-cd/screwdriver/pull/1758
[3]: https://github.com/screwdriver-cd/coverage-base/pull/11

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.