### PR TITLE
feat(2763): upgrade build-bookend module version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 
 > Screwdriver bookend for uploading code coverage reports and/or test results
 
-## Deprecated
-
-**Please note that this code is no longer used by the screwdriver.cd team and has not been maintained in a while. You are welcome to use and/or contribute to it at your own risk.**
-
 ## Usage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "./node_modules/.bin/semantic-release"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/coverage-bookend.git"
+    "url": "git+https://github.com/screwdriver-cd/coverage-bookend.git"
   },
   "homepage": "https://github.com/screwdriver-cd/coverage-bookend",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -39,12 +39,12 @@
     "sinon": "^5.0.3"
   },
   "dependencies": {
-    "screwdriver-build-bookend": "^2.3.0"
+    "screwdriver-build-bookend": "^3.0.0"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "branches": [
+      "master"
+    ],
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

`screwdriver-build-bookend@v3.0.0` has released.

https://github.com/screwdriver-cd/build-bookend/pull/22

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR upgrade `screwdriver-build-bookend` module version.
There are no changes to `BookendInterface` with [this upgrade](https://github.com/screwdriver-cd/build-bookend/compare/v2.4.0...v3.0.0).

And updates package.json to fix semantic release.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://cd.screwdriver.cd/pipelines/1/builds/827090/steps/duplicate

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
