### PR TITLE
fix: Update mocha and bump to node:12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_STORE
 .*.swp
 package-lock.json
+.nyc_output/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { BookendInterface } = require('screwdriver-build-bookend');
+const logger = require('screwdriver-logger');
 
 class CoverageBookend extends BookendInterface {
     /**
@@ -25,7 +26,7 @@ class CoverageBookend extends BookendInterface {
             // eslint-disable-next-line global-require, import/no-dynamic-require
             CoveragePlugin = require(`screwdriver-coverage-${pluginName}`);
         } catch (e) {
-            console.warn(`Coverage plugin ${pluginName} is not supported`);
+            logger.warn(`Coverage plugin ${pluginName} is not supported`);
 
             return;
         }

--- a/mocha.config.json
+++ b/mocha.config.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec, mocha-sonarqube-reporter",
+    "mochaSonarqubeReporterReporterOptions": {
+        "output": "./artifacts/report/test.xml"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true",
     "semantic-release": "./node_modules/.bin/semantic-release"
   },
   "repository": {
@@ -30,10 +30,11 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.6",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "mocha-multi-reporters": "^1.5.1",
+    "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.1.0",
     "screwdriver-coverage-base": "^1.0.1",
     "sinon": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   ],
   "devDependencies": {
     "chai": "^4.3.6",
-    "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.1",
+    "eslint": "^7.32.0",
+    "eslint-config-screwdriver": "^5.0.7",
+    "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,13 @@
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.1.0",
+    "nyc": "^15.1.0",
     "screwdriver-coverage-base": "^1.0.1",
     "sinon": "^5.0.3"
   },
   "dependencies": {
-    "screwdriver-build-bookend": "^3.0.0"
+    "screwdriver-build-bookend": "^3.0.0",
+    "screwdriver-logger": "^1.1.0"
   },
   "release": {
     "branches": [

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,10 +1,10 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:
         environment:
-            SD_SONAR_OPTS: "-Dsonar.sources=index.js -Dsonar.javascript.lcov.reportPath=artifacts/coverage/lcov.info"
+            SD_SONAR_OPTS: "-Dsonar.sources=lib -Dsonar.tests=test -Dsonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info -Dsonar.testExecutionReportPaths=artifacts/report/test.xml"
         requires: [~pr, ~commit]
         steps:
             - install: npm install

--- a/test/data/testCoverage.js
+++ b/test/data/testCoverage.js
@@ -2,7 +2,7 @@
 
 const CoverageBase = require('screwdriver-coverage-base');
 
-module.exports = (stubsMap) => {
+module.exports = stubsMap => {
     /**
      * Generic coverage class for testing
      * @type {Class}
@@ -13,7 +13,7 @@ module.exports = (stubsMap) => {
 
             this.options = options;
 
-            Object.keys(stubsMap).forEach((key) => {
+            Object.keys(stubsMap).forEach(key => {
                 this[key] = stubsMap[key];
             });
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('chai').assert;
+const { assert } = require('chai');
 const mockery = require('mockery');
 const sinon = require('sinon');
 const testCoverage = require('./data/testCoverage');
@@ -10,7 +10,7 @@ describe('index test', () => {
     let bookend;
     const exampleCoverageMock = {
         _getAccessToken: sinon.stub(),
-        _getUploadCoverageCmd: sinon.stub().resolves('Command to upload coverage')
+        getUploadCoverageCmd: sinon.stub().resolves('Command to upload coverage')
     };
     const config = {
         plugin: 'example',
@@ -27,8 +27,7 @@ describe('index test', () => {
     });
 
     beforeEach(() => {
-        mockery.registerMock('screwdriver-coverage-example',
-            testCoverage(exampleCoverageMock));
+        mockery.registerMock('screwdriver-coverage-example', testCoverage(exampleCoverageMock));
 
         // eslint-disable-next-line global-require
         CoverageBookend = require('../index');
@@ -52,9 +51,13 @@ describe('index test', () => {
         });
 
         it('throws an error when the coverage config is not an object', () => {
-            assert.throws(() => {
-                bookend = new CoverageBookend('meow');
-            }, Error, 'No coverage config passed in.');
+            assert.throws(
+                () => {
+                    bookend = new CoverageBookend('meow');
+                },
+                Error,
+                'No coverage config passed in.'
+            );
         });
 
         it('does not throw an error when a npm module cannot be registered', () => {
@@ -72,14 +75,11 @@ describe('index test', () => {
     });
 
     it('getSetupCommand', () =>
-        bookend.getSetupCommand().then((result) => {
+        bookend.getSetupCommand().then(result => {
             assert.strictEqual(result, '');
-        })
-    );
+        }));
 
     it('getTeardownCommand', () => {
-        bookend.getTeardownCommand().then(result =>
-            assert.deepEqual(result, 'Command to upload coverage')
-        );
+        bookend.getTeardownCommand().then(result => assert.deepEqual(result, 'Command to upload coverage'));
     });
 });


### PR DESCRIPTION
## Context

Mocha is out of date and sonar is broken.

## Objective

This PR updates mocha and bumps to node:12. Also updates eslint.

## References

Related to https://github.com/screwdriver-cd/models/pull/482/files

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
